### PR TITLE
Jekyll plugin to remove widows in talk titles.

### DIFF
--- a/_plugins/widont.rb
+++ b/_plugins/widont.rb
@@ -1,0 +1,13 @@
+require "liquid"
+
+module Jekyll
+  module WidontFilter
+    
+    def widont(text)
+      text.gsub(/\b\s(\S*?)$/, '&nbsp;\1')
+    end
+
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::WidontFilter)

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ layout: default
 			<ul class="posts">
 				{% for post in site.posts %}
 					{% assign author = post.author %}
-					<li><a href="{{ post.url }}">{% if author %}<span class="avatar{% if post.author-count %} avatar-count-{{ post.author-count }}{% endif %}">{% include avatars.html %}</span>{% endif %}{{ post.title }}</a>{% if post.videolength %} <span class="videolength">{{ post.videolength }}</span>{% endif %}</li>
+					<li><a href="{{ post.url }}">{% if author %}<span class="avatar{% if post.author-count %} avatar-count-{{ post.author-count }}{% endif %}">{% include avatars.html %}</span>{% endif %}{{ post.title | widont }}</a>{% if post.videolength %} <span class="videolength">{{ post.videolength }}</span>{% endif %}</li>
 				{% endfor %}
 			</ul>
 		</article>


### PR DESCRIPTION
A commit of personal aesthetic choice.  Inserts a <tt>&amp;nbsp;</tt> at the end of post titles to prevent [widows](https://en.wikipedia.org/wiki/Widows_and_orphans).

This

![Before](http://dropit.velvetcache.org.s3.amazonaws.com/jmhobbs/NTQyv9v0Cw/Screen-Shot.png)

becomes this

![After](http://dropit.velvetcache.org.s3.amazonaws.com/jmhobbs/NTQzTTgW0w/Screen-Shot.png)